### PR TITLE
Fixed issue where planutils solvers would not be able to run

### DIFF
--- a/server/api/Dockerfile
+++ b/server/api/Dockerfile
@@ -7,7 +7,6 @@ ENV C_FORCE_ROOT true
 ENV HOST 0.0.0.0
 ENV PORT 5001
 ENV DEBUG true
-ENV PATH ~/.planutils/bin:$PATH
 
 COPY . /api
 WORKDIR /api

--- a/server/api/Dockerfile
+++ b/server/api/Dockerfile
@@ -7,6 +7,7 @@ ENV C_FORCE_ROOT true
 ENV HOST 0.0.0.0
 ENV PORT 5001
 ENV DEBUG true
+ENV PATH ~/.planutils/bin:$PATH
 
 COPY . /api
 WORKDIR /api

--- a/server/api/app.py
+++ b/server/api/app.py
@@ -59,7 +59,8 @@ def index():
         problem_url = pddl_files.url(filename_problem)
 
         # Test to call celery with a couple of solvers
-        solvers = {"lama","bfws"}
+
+        solvers = {"downward --alias lama-first"}
         for solver in solvers:
             task = celery.send_task('tasks.solve', args=[domain_url, problem_url, solver], kwargs={})
             flash( Markup(f"Solving domain <a href='{domain_url}'> uploaded_domain </a> and <a href='{problem_url}'> uploaded_problem </a>: Task ID: {task.id} - <a href='{url_for('check_task', task_id=task.id, external=True)}'>check status of {task.id} </a>"))

--- a/server/api/app.py
+++ b/server/api/app.py
@@ -60,7 +60,7 @@ def index():
 
         # Test to call celery with a couple of solvers
 
-        solvers = {"downward --alias lama-first"}
+        solvers = {"lama-first"}
         for solver in solvers:
             task = celery.send_task('tasks.solve', args=[domain_url, problem_url, solver], kwargs={})
             flash( Markup(f"Solving domain <a href='{domain_url}'> uploaded_domain </a> and <a href='{problem_url}'> uploaded_problem </a>: Task ID: {task.id} - <a href='{url_for('check_task', task_id=task.id, external=True)}'>check status of {task.id} </a>"))

--- a/server/celery-queue/Dockerfile
+++ b/server/celery-queue/Dockerfile
@@ -11,8 +11,6 @@ ENV PATH=$PATH:~/.planutils/bin
 COPY . /queue
 WORKDIR /queue
 
-# Grabbing downward and lama
-RUN planutils install -f downward
 RUN planutils install -f lama
 
 RUN pip install -r requirements.txt

--- a/server/celery-queue/Dockerfile
+++ b/server/celery-queue/Dockerfile
@@ -6,12 +6,15 @@ ENV CELERY_BROKER_URL redis://redis:6379/0
 ENV CELERY_RESULT_BACKEND redis://redis:6379/0
 ENV C_FORCE_ROOT true
 ENV WEB_DOCKER_URL web
+ENV PATH=$PATH:~/.planutils/bin
 
 COPY . /queue
 WORKDIR /queue
 
-RUN pip install -r requirements.txt
-
+# Grabbing downward and lama
+RUN planutils install -f downward
 RUN planutils install -f lama
+
+RUN pip install -r requirements.txt
 
 ENTRYPOINT celery -A tasks worker --loglevel=info

--- a/server/celery-queue/tasks.py
+++ b/server/celery-queue/tasks.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import time
 import tempfile
 import requests
@@ -40,9 +41,9 @@ def solve(domain_url: str, problem_url: str, solver: str) -> str:
     # remove the tmp/fies once we finish
     os.remove( domain_file )
     os.remove( problem_file )
-    os.rmdir(tmpfolder)
+    shutil.rmtree(tmpfolder)
 
-    return {'stdout': res.stdout, 'stderr': res.stderr}
+    return {'stdout': res.stdout, 'stderr': res.stderr}    
 
 @celery.task(name='tasks.add')
 def add(x: int, y: int) -> int:

--- a/server/celery-queue/tasks.py
+++ b/server/celery-queue/tasks.py
@@ -43,7 +43,7 @@ def solve(domain_url: str, problem_url: str, solver: str) -> str:
     os.remove( problem_file )
     shutil.rmtree(tmpfolder)
 
-    return {'stdout': res.stdout, 'stderr': res.stderr}    
+    return {'stdout': res.stdout, 'stderr': res.stderr}
 
 @celery.task(name='tasks.add')
 def add(x: int, y: int) -> int:


### PR DESCRIPTION
Made a few fixes, mainly two:

Added ~/.planutils/bin to the env for the worker, which allows for us to use any installed planutils tools. Also changed os.rmdir to shutil rmdir functionality which allows us to remove non-empty directories. 

I've changed the default planner to be lama-first, because lama seemed to run indefinitely when I was testing.