### PR TITLE
[55] Fix planning editor adaptor

### DIFF
--- a/server/api/adaptor/planning_editor_adaptor/action_plan_parser/predicate.py
+++ b/server/api/adaptor/planning_editor_adaptor/action_plan_parser/predicate.py
@@ -1,3 +1,5 @@
+import re
+
 class Predicate (object):
     """
         Simple data structure for the predicate objects.
@@ -114,9 +116,12 @@ class Predicate (object):
             arg_s = " ".join (["%s - %s" % (v, t) for v, t in l])
         else:
             arg_s = " ".join ([v for v, t in l])
-        
-        for k in grounding:
-            arg_s = arg_s.replace(k, grounding[k])
+
+        # Create a regex pattern that matches the keys exactly
+        pattern = '|'.join(re.escape(key) for key in sorted(grounding.keys(), key=len, reverse=True))
+
+        # Use re.sub() to replace all matched keys to their corresponding value
+        arg_s = re.sub(pattern, lambda match: grounding[match.group(0)], arg_s)
 
         return (sp * lvl) + "(%s%s%s)" % (self.name, sep, arg_s)
 


### PR DESCRIPTION
**Description:**
The issue stems from the way parameters are parsed in the planning_editor_adaptor when one parameter is a substring of another. For instance, in the Floortile domain (see issue #55), the parameter '?c' was incorrectly parsed as '?c2' due to partial matches.


**Root cause:**
This misinterpretation is traced back to the code in predicate.py, lines 118-119:
https://github.com/AI-Planning/planning-as-a-service/blob/3ef6c88d9d9b8f1cab1f092f1a2993ef06ecd1d1/server/api/adaptor/planning_editor_adaptor/action_plan_parser/predicate.py#L118-L119


**Solution**
A regex-based solution has been implemented, which ensures exact matching of keys. The keys are ordered by length in descending order to prevent partial matches and ensure accurate replacement of parameters in actions.


Resolves #55