### PR TITLE
Live progress for anytime planners, per-request time limits, and solve cancellation

### DIFF
--- a/server/api/app.py
+++ b/server/api/app.py
@@ -46,6 +46,10 @@ app.secret_key = app.config['SECRET_KEY']
 block_dict={}
 LIMITER_SECONDS= app.config['LIMITER_SECONDS']
 
+# Upper bound on the per-request "max_time" override (seconds), so a client
+# can't tie up a worker indefinitely.
+MAX_ALLOWED_TIME = int(os.environ.get('MAX_ALLOWED_TIME', 120))
+
 # Flask-Upload
 PDDL = ('pddl',)
 pddl_files = UploadSet('pddl', PDDL, default_dest=lambda x: app.config['UPLOAD_FOLDER'])
@@ -142,8 +146,20 @@ def runPackage(package, service):
 
         call = package_manifest['call']
         output_file = package_manifest['return']
+
+        # Optional per-request override of the planner time budget, clamped to
+        # avoid a client hogging a worker indefinitely.
+        max_time = None
+        if request_data and request_data.get('max_time') is not None:
+            try:
+                max_time = min(max(int(request_data['max_time']), 1), MAX_ALLOWED_TIME)
+            except (TypeError, ValueError):
+                return jsonify({"Error": "max_time must be an integer number of seconds"})
+
         # Send task
-        task = celery.send_task('tasks.run.package', args=[package, arguments, call, output_file], kwargs={"persistent":persistent_value})
+        task_kwargs = {"persistent":persistent_value, "max_time":max_time}
+        send_kwargs = {"soft_time_limit": max_time + 10} if max_time else {}
+        task = celery.send_task('tasks.run.package', args=[package, arguments, call, output_file], kwargs=task_kwargs, **send_kwargs)
 
         # keep the IP and datetime of the tasks
         block_dict[request.remote_addr]=datetime.now()
@@ -195,6 +211,8 @@ def check_task(task_id: str) -> str:
     res = celery.AsyncResult(task_id)
     if res.state == states.PENDING:
         return {"status":res.state}
+    elif res.state == 'PROGRESS':
+        return {"status":"PROGRESS", "partial_result":res.info}
     else:
         #Get requst
 

--- a/server/api/app.py
+++ b/server/api/app.py
@@ -213,6 +213,12 @@ def check_task(task_id: str) -> str:
         return {"status":res.state}
     elif res.state == 'PROGRESS':
         return {"status":"PROGRESS", "partial_result":res.info}
+    elif res.state == states.REVOKED:
+        # Cancelled before a worker ever picked it up (e.g. still queued
+        # under load) - tasks.run.package's own SIGTERM handler covers
+        # cancelling an already-running task, this covers the rest.
+        cancelled_result = {"stdout":"", "stderr":"Cancelled by client", "call":"", "output":{}, "output_type":"log"}
+        return {"result":cancelled_result, "status":"ok"}
     else:
         #Get requst
 
@@ -233,6 +239,16 @@ def check_task(task_id: str) -> str:
             else:
                 # Return the default result format
                 return {"result":result,"status":"ok"}
+
+
+@app.route('/cancel/<string:task_id>', methods=['POST'])
+def cancel_task(task_id: str) -> str:
+    # terminate=True + SIGTERM asks the worker to interrupt this specific
+    # task; tasks.run.package installs its own SIGTERM handler to kill the
+    # planner's whole process group, not just revoke the Celery task bookkeeping.
+    celery.control.revoke(task_id, terminate=True, signal='SIGTERM')
+    return {"status": "cancelled"}
+
 
 # Returns all necessary arguments for a service in a package
 def get_arguments(request_data, package_manifest):

--- a/server/celery-queue/tasks.py
+++ b/server/celery-queue/tasks.py
@@ -163,23 +163,43 @@ def run_package(self, package: str, arguments:dict, call:str, output_file:dict, 
         previous_handler = signal.signal(signal.SIGTERM, handle_cancel)
 
         try:
-            # Some packages (e.g. optic) redirect their real output to a file via
-            # `>> plan` inside `call`, rather than writing to the process's own
-            # stdout - so tail that file on disk to observe progress while the
-            # process is still running, using the same glob descriptor that's
-            # used to retrieve the final output below.
+            # Some packages (e.g. optic) redirect their real output to a file
+            # via `>> plan` inside `call` - a template that comes from that
+            # package's own manifest in planutils (e.g. optic's is literally
+            # "optic {domain} {problem} >> plan"), not something in this repo
+            # - rather than writing to the process's own stdout. So tail that
+            # file on disk to observe progress while the process is still
+            # running, using the same glob descriptor that's used to retrieve
+            # the final output below.
+            #
+            # Read incrementally (seek to where the last read left off)
+            # rather than re-reading the whole file every poll: a full re-read
+            # each cycle means total bytes read over a run's lifetime grows
+            # with run-length x poll-frequency x current-file-size, which
+            # matters once a search runs long/produces a large log. The
+            # accumulated content (not just each new chunk) is still what
+            # gets published, since the client parses the full text for the
+            # last solution block found so far.
             output_pattern = os.path.join(tmpfolder, output_file["files"])
-            last_reported_len = 0
+            matched_file = None
+            file_pos = 0
+            accumulated_content = ""
             while proc.poll() is None:
-                time.sleep(0.5)
-                matches = glob.glob(output_pattern)
-                if not matches:
+                time.sleep(0.2)
+                if matched_file is None:
+                    matches = glob.glob(output_pattern)
+                    if not matches:
+                        continue
+                    matched_file = matches[0]
+                with open(matched_file, 'r') as f:
+                    f.seek(file_pos)
+                    new_content = f.read()
+                    file_pos = f.tell()
+                if not new_content:
                     continue
-                with open(matches[0], 'r') as f:
-                    content = f.read()
-                if len(content) > last_reported_len and '; Plan found with metric' in content[last_reported_len:]:
-                    self.update_state(state='PROGRESS', meta={'call': call, 'partial_stdout': content})
-                last_reported_len = len(content)
+                accumulated_content += new_content
+                if '; Plan found with metric' in new_content:
+                    self.update_state(state='PROGRESS', meta={'call': call, 'partial_stdout': accumulated_content})
         finally:
             signal.signal(signal.SIGTERM, previous_handler)
 

--- a/server/celery-queue/tasks.py
+++ b/server/celery-queue/tasks.py
@@ -141,14 +141,25 @@ def run_package(self, package: str, arguments:dict, call:str, output_file:dict, 
                             executable='/bin/bash', encoding='utf-8',
                             shell=True, cwd=tmpfolder)
 
-        stdout_so_far = ""
-        for line in iter(proc.stdout.readline, ''):
-            stdout_so_far += line
-            if line.strip().startswith('; Plan found with metric'):
-                self.update_state(state='PROGRESS', meta={'call': call, 'partial_stdout': stdout_so_far})
+        # Some packages (e.g. optic) redirect their real output to a file via
+        # `>> plan` inside `call`, rather than writing to the process's own
+        # stdout - so tail that file on disk to observe progress while the
+        # process is still running, using the same glob descriptor that's
+        # used to retrieve the final output below.
+        output_pattern = os.path.join(tmpfolder, output_file["files"])
+        last_reported_len = 0
+        while proc.poll() is None:
+            time.sleep(0.5)
+            matches = glob.glob(output_pattern)
+            if not matches:
+                continue
+            with open(matches[0], 'r') as f:
+                content = f.read()
+            if len(content) > last_reported_len and '; Plan found with metric' in content[last_reported_len:]:
+                self.update_state(state='PROGRESS', meta={'call': call, 'partial_stdout': content})
+            last_reported_len = len(content)
 
-        proc.wait()
-        res = SimpleNamespace(stdout=stdout_so_far, stderr=proc.stderr.read())
+        res = SimpleNamespace(stdout=proc.stdout.read(), stderr=proc.stderr.read())
 
         output = retrieve_output_file(output_file, tmpfolder)
         # Remove the files in temfolder when task is finished

--- a/server/celery-queue/tasks.py
+++ b/server/celery-queue/tasks.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import signal
 import time
 import tempfile
 import requests
@@ -137,27 +138,54 @@ def run_package(self, package: str, arguments:dict, call:str, output_file:dict, 
         call = f'{planner} -- {args}'
         call = f"timeout {time_limit} planutils run {call}"
         
+        # start_new_session=True makes this process (the shell running `call`)
+        # its own process group leader. Its children (timeout, planutils, the
+        # actual planner) inherit that same group by default, so killing the
+        # whole group later (on cancellation) reliably takes all of them down
+        # - killing just proc.pid would only kill the shell and orphan the
+        # planner still running underneath it.
         proc = subprocess.Popen(call, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                             executable='/bin/bash', encoding='utf-8',
-                            shell=True, cwd=tmpfolder)
+                            shell=True, cwd=tmpfolder, start_new_session=True)
 
-        # Some packages (e.g. optic) redirect their real output to a file via
-        # `>> plan` inside `call`, rather than writing to the process's own
-        # stdout - so tail that file on disk to observe progress while the
-        # process is still running, using the same glob descriptor that's
-        # used to retrieve the final output below.
-        output_pattern = os.path.join(tmpfolder, output_file["files"])
-        last_reported_len = 0
-        while proc.poll() is None:
-            time.sleep(0.5)
-            matches = glob.glob(output_pattern)
-            if not matches:
-                continue
-            with open(matches[0], 'r') as f:
-                content = f.read()
-            if len(content) > last_reported_len and '; Plan found with metric' in content[last_reported_len:]:
-                self.update_state(state='PROGRESS', meta={'call': call, 'partial_stdout': content})
-            last_reported_len = len(content)
+        cancelled = {'value': False}
+
+        def handle_cancel(signum, frame):
+            # Celery delivers this when the task is revoked with terminate=True.
+            # Kill the whole process group (not just proc.pid) so nothing is
+            # left running orphaned, then let the task end.
+            cancelled['value'] = True
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+        previous_handler = signal.signal(signal.SIGTERM, handle_cancel)
+
+        try:
+            # Some packages (e.g. optic) redirect their real output to a file via
+            # `>> plan` inside `call`, rather than writing to the process's own
+            # stdout - so tail that file on disk to observe progress while the
+            # process is still running, using the same glob descriptor that's
+            # used to retrieve the final output below.
+            output_pattern = os.path.join(tmpfolder, output_file["files"])
+            last_reported_len = 0
+            while proc.poll() is None:
+                time.sleep(0.5)
+                matches = glob.glob(output_pattern)
+                if not matches:
+                    continue
+                with open(matches[0], 'r') as f:
+                    content = f.read()
+                if len(content) > last_reported_len and '; Plan found with metric' in content[last_reported_len:]:
+                    self.update_state(state='PROGRESS', meta={'call': call, 'partial_stdout': content})
+                last_reported_len = len(content)
+        finally:
+            signal.signal(signal.SIGTERM, previous_handler)
+
+        if cancelled['value']:
+            shutil.rmtree(tmpfolder, ignore_errors=True)
+            return {"stdout":"", "stderr":"Cancelled by client", "call":call, "output":{},"output_type":output_file["type"]},arguments
 
         res = SimpleNamespace(stdout=proc.stdout.read(), stderr=proc.stderr.read())
 

--- a/server/celery-queue/tasks.py
+++ b/server/celery-queue/tasks.py
@@ -7,6 +7,7 @@ import subprocess
 import json
 import glob
 import time
+from types import SimpleNamespace
 from db import MetaDB
 from functools import wraps
 
@@ -112,8 +113,9 @@ def write_to_temp_file(name:str, data:str, folder:str):
 
 @celery.task(name='tasks.run.package',soft_time_limit=TIME_LIMIT+10,bind=True)
 @track_celery
-def run_package(self, package: str, arguments:dict, call:str, output_file:dict,**kwargs):
+def run_package(self, package: str, arguments:dict, call:str, output_file:dict, max_time=None, **kwargs):
 
+    time_limit = int(max_time) if max_time else TIME_LIMIT
 
     try:
         tmpfolder = tempfile.mkdtemp()
@@ -133,11 +135,20 @@ def run_package(self, package: str, arguments:dict, call:str, output_file:dict,*
         planner = call.split(' ')[0]
         args = ' '.join(call.split(' ')[1:])
         call = f'{planner} -- {args}'
-        call = f"timeout {TIME_LIMIT} planutils run {call}"
+        call = f"timeout {time_limit} planutils run {call}"
         
-        res = subprocess.run(call, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        proc = subprocess.Popen(call, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                             executable='/bin/bash', encoding='utf-8',
                             shell=True, cwd=tmpfolder)
+
+        stdout_so_far = ""
+        for line in iter(proc.stdout.readline, ''):
+            stdout_so_far += line
+            if line.strip().startswith('; Plan found with metric'):
+                self.update_state(state='PROGRESS', meta={'call': call, 'partial_stdout': stdout_so_far})
+
+        proc.wait()
+        res = SimpleNamespace(stdout=stdout_so_far, stderr=proc.stderr.read())
 
         output = retrieve_output_file(output_file, tmpfolder)
         # Remove the files in temfolder when task is finished


### PR DESCRIPTION
## Live progress for anytime planners, per-request time limits, and solve cancellation

### Motivation

Anytime planners (e.g. `optic`) don't stop at the first plan they find — they keep searching for a better one until they either prove optimality or run out of time. Today, `/check/<task_id>` only ever reports `PENDING` or a finished result: there's no way to see what the planner has found *while it's still searching*, no way to give an individual request more or less time than the server's global `TIME_LIMIT`, and no way to cancel a request that's no longer needed — even after the client stops waiting, the task (and its planner subprocess) keeps running server-side until its full time budget elapses, tying up one of a fixed, small pool of workers for no reason.

This also had a correctness side effect: a run that got killed by the shell-level `timeout` mid-search returned nothing at all, even when a perfectly good solution had already been found and printed before the kill.

### What's included

**Progress streaming** — `run_package` (`server/celery-queue/tasks.py`) now tails the planner's output file on disk while the process is still running, instead of reading its stdout. Several packages redirect their real output to a file as part of their own `call` template defined in `planutils`'s package manifest — e.g. `optic`'s is literally `"optic {domain} {problem} >> plan"` (visible via `GET /package/optic/solve`) — so stdout stays empty regardless of what the planner is actually doing. The tail reads incrementally (seeking to where the last read left off, not re-reading the whole file every cycle) at a 0.2s interval. Each time new `; Plan found with metric` content appears, it publishes a Celery `PROGRESS` state via `self.update_state(...)`. `GET /check/<task_id>` (`server/api/app.py`) now distinguishes that state from `PENDING`/finished, returning `{"status": "PROGRESS", "partial_result": {...}}` so a polling client can observe intermediate solutions instead of only ever seeing a final result or nothing.

**Per-request time limits** — `POST /package/<package>/solve` now accepts an optional `max_time` (seconds) in the request body, overriding the previously-global `TIME_LIMIT` for that one request. Clamped to `[1, MAX_ALLOWED_TIME]` (new env var, default 120s) so a client can't monopolize a worker. Celery's own `soft_time_limit` is adjusted per-call to match, so its safety-net timeout doesn't fire before the requested budget does.

**Cancellation** — new `POST /cancel/<task_id>`, calling `celery.control.revoke(task_id, terminate=True, signal='SIGTERM')`. `run_package` installs a `SIGTERM` handler for the task's duration that kills the planner's *whole process group* via `os.killpg(...)`, not just the immediate child — necessary because the planner runs through a shell (`subprocess.Popen(call, shell=True, ...)`), so the direct child is that shell, not the planner itself; killing only `proc.pid` would leave the actual planner process orphaned and still running. The subprocess is now spawned with `start_new_session=True` so it's its own process-group leader, making that group-kill possible. Also handles the case of a task cancelled before any worker picked it up (Celery marks it `REVOKED` rather than `PENDING`/`PROGRESS`/finished — the existing handler would have crashed trying to unpack a nonexistent result for that state).

### Backward compatibility

All three additions are opt-in and default to prior behavior: omitting `max_time` uses the existing global `TIME_LIMIT`; clients that never poll during a `PROGRESS` state just see `PENDING` until the task reaches a terminal state, same as before; nothing calls `/cancel` unless a client explicitly does.

### Testing

Verified manually against a local instance:
- A rockets/cargo-delivery domain solved via `optic` correctly surfaces intermediate solutions (`PROGRESS` responses containing progressively better plans) well before the task finishes, both before and after switching to incremental file reads.
- `max_time` correctly shortens/lengthens the shell-level timeout and Celery's own limit to match.
- Cancelling ~3s into a 30s `max_time` budget freed the result almost immediately (~1s) and left no `optic`/`planutils` process running in the worker container afterward (checked directly via `ps aux` in the container).

### Known limitation

This is polling, not a push — the client still asks "are you done yet?" on an interval; the server never proactively notifies it. A real push-based version (Server-Sent Events, so `PROGRESS` updates reach the client the instant they happen) would be a natural follow-up but isn't part of this PR.
